### PR TITLE
bump hc to `24ceb63`; bump version to alpha1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,16 +1,16 @@
 let
   holonixPath = builtins.fetchTarball {
-    url = "https://github.com/holochain/holonix/archive/9a1f11bacf0a4a8d5cfb83b449df5f726c569c7c.tar.gz";
-    sha256 = "0j4v354rlipifw2ibydr02nv6bwm33vv63197srswkvv6wi6dr9c";
+    url = "https://github.com/holochain/holonix/archive/3e94163765975f35f7d8ec509b33c3da52661bd1.tar.gz";
+    sha256 = "07sl281r29ygh54dxys1qpjvlvmnh7iv1ppf79fbki96dj9ip7d2";
   };
   holonix = import (holonixPath) {
     includeHolochainBinaries = true;
     holochainVersionId = "custom";
 
     holochainVersion = {
-     rev = "a1ae76ecc1fc7dbd645fee3a8cb0df9f610be983";
-     sha256 = "04kha2vxzh3ml452xsdz40f3jbchlad0lf741862n56x4np2spa2";
-     cargoSha256 = "0q9nl0wqvyd5jbxq92f1h4l7i439kl5j1bkzxlz929q4m43r3apn";
+     rev = "24ceb63bdea374d1936b723e1966caf2e55ebfdc";
+     sha256 = "16hsikyasi0zbh7gfrpzlahydx7csnvshz421sx56f0jpwvi2g80";
+     cargoSha256 = "0w29y8w5k5clq74k84ksj5aqxbxhqxh2djhll6vv694djw277rpj";
      bins = {
        holochain = "holochain";
        hc = "hc";

--- a/tests/unit-test/endpoints.ts
+++ b/tests/unit-test/endpoints.ts
@@ -44,7 +44,7 @@ module.exports = async (orchestrator) => {
       t.fail()
     }
 
-    // test fn: pass_obj()
+    // test fn: return_failure()
     try {
       response = await alice.call('test', 'return_failure', null);
     } catch(e) {

--- a/zomes/test/Cargo.toml
+++ b/zomes/test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test"
-version = "0.1.0"
-authors = [ "zo-el", "joelulahanna@gmail.com" ]
+version = "0.1.0-alpha1"
+authors = [ "zo-el <joelulahanna@gmail.com>", "jetttech <lisa.jetton@holo.host>" ]
 edition = "2018"
 
 [lib]
@@ -9,7 +9,7 @@ name = "test"
 crate-type = [ "cdylib", "rlib" ]
 
 [dependencies]
-hdk = { git = "https://github.com/holochain/holochain", rev = "1050f6b064a44a6d6b845940bf4b83cb92f0472f", package = "hdk" }
+hdk = { git = "https://github.com/holochain/holochain", rev = "24ceb63bdea374d1936b723e1966caf2e55ebfdc", package = "hdk" }
 serde = "1.0.104"
 thiserror = "1.0.22"
 paste = "1.0.5"


### PR DESCRIPTION
### Updates:
  -  bumps holochain rev to `24ceb63bdea374d1936b723e1966caf2e55ebfdc`
  - updates version to 0.1.0-alpha1