### PR TITLE
Update default cap grants

### DIFF
--- a/zomes/test/src/lib.rs
+++ b/zomes/test/src/lib.rs
@@ -30,8 +30,8 @@ pub fn set_cap_tokens() -> ExternResult<()> {
     functions.insert((zome_info()?.name, "return_failure".into()));
     functions.insert((zome_info()?.name, "create_link".into()));
     functions.insert((zome_info()?.name, "delete_link".into()));
-    functions.insert((zome_info()?.name, "get_link".into()));
-    functions.insert((zome_info()?.name, "delete_all_link".into()));
+    functions.insert((zome_info()?.name, "get_links".into()));
+    functions.insert((zome_info()?.name, "delete_all_links".into()));
     functions.insert((zome_info()?.name, "signal_loopback".into()));
     functions.insert((zome_info()?.name, "emit_signal_from_sibling_cell".into()));
     create_cap_grant(CapGrantEntry {

--- a/zomes/test/src/lib.rs
+++ b/zomes/test/src/lib.rs
@@ -28,10 +28,7 @@ pub fn set_cap_tokens() -> ExternResult<()> {
     functions.insert((zome_info()?.name, "returns_obj".into()));
     functions.insert((zome_info()?.name, "pass_obj".into()));
     functions.insert((zome_info()?.name, "return_failure".into()));
-    functions.insert((zome_info()?.name, "create_link".into()));
-    functions.insert((zome_info()?.name, "delete_link".into()));
     functions.insert((zome_info()?.name, "get_links".into()));
-    functions.insert((zome_info()?.name, "delete_all_links".into()));
     functions.insert((zome_info()?.name, "signal_loopback".into()));
     functions.insert((zome_info()?.name, "emit_signal_from_sibling_cell".into()));
     create_cap_grant(CapGrantEntry {


### PR DESCRIPTION
This fixes a bad zome name (`get_link` -> `get_links`) and removes default cap grants for zome calls that write to the source chain.