### PR TITLE
bump to test v0.5.0 and test-integrity v0.1.0

### DIFF
--- a/zomes/test/Cargo.toml
+++ b/zomes/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test"
-version = "0.4.4"
+version = "0.5.0"
 authors = [ "zo-el <joelulahanna@gmail.com>", "jetttech <lisa.jetton@holo.host>" ]
 edition = "2021"
 


### PR DESCRIPTION
### Updates:
 - bump the zome versions in prep for release